### PR TITLE
Add disassembler regression test for arm64 LDAPRB (#112)

### DIFF
--- a/Bit Slicer Tests/DisassemblerTest.m
+++ b/Bit Slicer Tests/DisassemblerTest.m
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Mayur Pawashe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the project's author nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "ZGCapstoneDisassemblerObject.h"
+#import "ZGInstruction.h"
+#import "ZGVariable.h"
+
+@interface DisassemblerTest : XCTestCase
+
+@end
+
+@implementation DisassemblerTest
+
+- (NSArray<ZGInstruction *> *)disassembleARM64Bytes:(const void *)bytes size:(ZGMemorySize)size address:(ZGMemoryAddress)address
+{
+	ZGCapstoneDisassemblerObject *disassembler = [[ZGCapstoneDisassemblerObject alloc] initWithBytes:bytes address:address size:size pointerSize:sizeof(int64_t) isARM64:YES];
+	return [disassembler readInstructions];
+}
+
+// Regression test for issue #112: the ARMv8.3 (FEAT_LRCPC) load-acquire
+// instruction LDAPRB was emitted as raw bytes in the debugger view with older
+// versions of Capstone. Ensure it disassembles to a proper mnemonic so it does
+// not silently regress on future Capstone updates.
+- (void)testARM64LoadAcquireRCpcByte
+{
+	// LDAPRB w9, [x9]  ->  29 C1 BF 38  (encoding 0x38BFC129)
+	uint8_t bytes[] = {0x29, 0xC1, 0xBF, 0x38};
+	ZGMemoryAddress address = 0x100039970;
+
+	NSArray<ZGInstruction *> *instructions = [self disassembleARM64Bytes:bytes size:sizeof(bytes) address:address];
+
+	XCTAssertEqual(instructions.count, (NSUInteger)1);
+
+	ZGInstruction *instruction = instructions.firstObject;
+	XCTAssertEqualObjects(instruction.text, @"ldaprb w9, [x9]");
+	XCTAssertEqual(instruction.variable.address, address);
+	XCTAssertEqual(instruction.variable.size, (ZGMemorySize)sizeof(bytes));
+}
+
+@end

--- a/Bit Slicer.xcodeproj/project.pbxproj
+++ b/Bit Slicer.xcodeproj/project.pbxproj
@@ -24,6 +24,11 @@
 		721B3C4D2AED913200F85660 /* ZGSearchProtectionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 720C192B271B4F9700740C8E /* ZGSearchProtectionMode.m */; };
 		721B3C4E2AED91DC00F85660 /* NSStringAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 77F1163417D2EF6D009E002A /* NSStringAdditions.m */; };
 		722CAADF19BB625E009C6AAE /* VariableDisplayTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 722CAADE19BB625E009C6AAE /* VariableDisplayTest.m */; };
+		C0FFEE0000000000000000B1 /* DisassemblerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE0000000000000000F1 /* DisassemblerTest.m */; };
+		C0FFEE0000000000000000B2 /* ZGCapstoneDisassemblerObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 72ABCBED24E8DB9900EF63A9 /* ZGCapstoneDisassemblerObject.m */; };
+		C0FFEE0000000000000000B3 /* ZGInstruction.m in Sources */ = {isa = PBXBuildFile; fileRef = 77F1164517D2EFBD009E002A /* ZGInstruction.m */; };
+		C0FFEE0000000000000000B4 /* Capstone.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72ABCBE924E8D7D700EF63A9 /* Capstone.framework */; };
+		C0FFEE0000000000000000B5 /* Capstone.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 72ABCBE924E8D7D700EF63A9 /* Capstone.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		722CAAE119BBB5A1009C6AAE /* SearchVirtualMemoryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 722CAAE019BBB5A1009C6AAE /* SearchVirtualMemoryTest.m */; };
 		722CAAE219BBD7EE009C6AAE /* ZGStoredData.m in Sources */ = {isa = PBXBuildFile; fileRef = 77282122189E769B0044E4BC /* ZGStoredData.m */; };
 		722EE77D1B193ABD00934EF3 /* ZGVirtualMemoryStringReading.m in Sources */ = {isa = PBXBuildFile; fileRef = 722EE77C1B193ABD00934EF3 /* ZGVirtualMemoryStringReading.m */; };
@@ -279,6 +284,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				72ABCBC624E8BA8900EF63A9 /* HexFiend.framework in Copy Frameworks */,
+				C0FFEE0000000000000000B5 /* Capstone.framework in Copy Frameworks */,
 				7235B7B424D7D9EA0029580A /* DDMathParser.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -316,6 +322,7 @@
 		72130FFA2BF00FBD00691AED /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = "Bit Slicer/ru.lproj/[Code] Edit Variable Address.strings"; sourceTree = "<group>"; };
 		721594FD24DF36360027F600 /* HexFiend.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HexFiend.framework; path = deps/HexFiend/HexFiend.framework; sourceTree = "<group>"; };
 		722CAADE19BB625E009C6AAE /* VariableDisplayTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VariableDisplayTest.m; sourceTree = "<group>"; usesTabs = 1; };
+		C0FFEE0000000000000000F1 /* DisassemblerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DisassemblerTest.m; sourceTree = "<group>"; usesTabs = 1; };
 		722CAAE019BBB5A1009C6AAE /* SearchVirtualMemoryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SearchVirtualMemoryTest.m; sourceTree = "<group>"; usesTabs = 1; };
 		722EE74D1B18D8B000934EF3 /* ZGChosenProcessDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ZGChosenProcessDelegate.h; path = "Bit Slicer/ZGChosenProcessDelegate.h"; sourceTree = "<group>"; };
 		722EE74E1B18F8CC00934EF3 /* ZGShowMemoryWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ZGShowMemoryWindow.h; path = "Bit Slicer/ZGShowMemoryWindow.h"; sourceTree = "<group>"; };
@@ -773,6 +780,7 @@
 				77E2BBD518FD904400E41FA0 /* CoreSymbolication.framework in Frameworks */,
 				7235B7B524D7D9F40029580A /* DDMathParser.framework in Frameworks */,
 				72ABCBC524E8BA8200EF63A9 /* HexFiend.framework in Frameworks */,
+				C0FFEE0000000000000000B4 /* Capstone.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1189,6 +1197,7 @@
 				77E2BBD718FDC45F00E41FA0 /* PointerFunctionSubstitutionTest.m */,
 				77E2BBAD18FD88A700E41FA0 /* LinearExpressionParsingTest.m */,
 				722CAADE19BB625E009C6AAE /* VariableDisplayTest.m */,
+				C0FFEE0000000000000000F1 /* DisassemblerTest.m */,
 				77E2BBA818FD88A700E41FA0 /* Supporting Files */,
 			);
 			path = "Bit Slicer Tests";
@@ -1587,6 +1596,9 @@
 				77E2BBB718FD8F6B00E41FA0 /* ZGCalculator.m in Sources */,
 				77A5B03019189CC9002BEC69 /* BinarySearchTest.m in Sources */,
 				722CAADF19BB625E009C6AAE /* VariableDisplayTest.m in Sources */,
+				C0FFEE0000000000000000B1 /* DisassemblerTest.m in Sources */,
+				C0FFEE0000000000000000B2 /* ZGCapstoneDisassemblerObject.m in Sources */,
+				C0FFEE0000000000000000B3 /* ZGInstruction.m in Sources */,
 				776B62E6193126B7004BF4A0 /* ByteArraySearchTest.mm in Sources */,
 				77E2BBAE18FD88A700E41FA0 /* LinearExpressionParsingTest.m in Sources */,
 				77E2BBD818FDC45F00E41FA0 /* PointerFunctionSubstitutionTest.m in Sources */,
@@ -2358,6 +2370,7 @@
 					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
 					"$(PROJECT_DIR)/deps/DDMathParser",
 					"$(PROJECT_DIR)/deps/HexFiend",
+					"$(PROJECT_DIR)/deps/capstone",
 				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -2453,6 +2466,7 @@
 					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
 					"$(PROJECT_DIR)/deps/DDMathParser",
 					"$(PROJECT_DIR)/deps/HexFiend",
+					"$(PROJECT_DIR)/deps/capstone",
 				);
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;


### PR DESCRIPTION
Capstone 5.0.7 (82a1dfe) fixed decoding of the ARMv8.3 (FEAT_LRCPC) `LDAPRB` instruction reported in #112, but there was no disassembler test coverage. This adds a regression test asserting `29 C1 BF 38` decodes to `ldaprb w9, [x9]` via `ZGCapstoneDisassemblerObject`, guarding against future Capstone regressions.

This does not address the separate Keystone limitation (assembling `LDAPR*` fails on the unmaintained Keystone 0.9.2) also discussed in #112.