### PR TITLE
Only show elevated-privileges search error when the target runs as another user (#71)

### DIFF
--- a/Bit Slicer Tests/ProcessUserIDTest.m
+++ b/Bit Slicer Tests/ProcessUserIDTest.m
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Mayur Pawashe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the project's author nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "ZGProcess.h"
+#import <unistd.h>
+
+@interface ProcessUserIDTest : XCTestCase
+
+@end
+
+@implementation ProcessUserIDTest
+
+- (void)testCurrentProcessRunsAsCurrentUser
+{
+	uid_t userID = (uid_t)-1;
+	XCTAssertTrue([ZGProcess getUserID:&userID forProcessIdentifier:getpid()]);
+	XCTAssertEqual(userID, getuid());
+}
+
+- (void)testLaunchdRunsAsRoot
+{
+	// launchd is always pid 1 and runs as root (uid 0)
+	uid_t userID = (uid_t)-1;
+	XCTAssertTrue([ZGProcess getUserID:&userID forProcessIdentifier:1]);
+	XCTAssertEqual(userID, (uid_t)0);
+}
+
+- (void)testNonexistentProcessReturnsNo
+{
+	uid_t userID = (uid_t)-1;
+	XCTAssertFalse([ZGProcess getUserID:&userID forProcessIdentifier:999999]);
+}
+
+@end

--- a/Bit Slicer.xcodeproj/project.pbxproj
+++ b/Bit Slicer.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		721B3C4D2AED913200F85660 /* ZGSearchProtectionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 720C192B271B4F9700740C8E /* ZGSearchProtectionMode.m */; };
 		721B3C4E2AED91DC00F85660 /* NSStringAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 77F1163417D2EF6D009E002A /* NSStringAdditions.m */; };
 		722CAADF19BB625E009C6AAE /* VariableDisplayTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 722CAADE19BB625E009C6AAE /* VariableDisplayTest.m */; };
+		DEC0DE0000000000000000B1 /* ProcessUserIDTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC0DE0000000000000000F1 /* ProcessUserIDTest.m */; };
 		722CAAE119BBB5A1009C6AAE /* SearchVirtualMemoryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 722CAAE019BBB5A1009C6AAE /* SearchVirtualMemoryTest.m */; };
 		722CAAE219BBD7EE009C6AAE /* ZGStoredData.m in Sources */ = {isa = PBXBuildFile; fileRef = 77282122189E769B0044E4BC /* ZGStoredData.m */; };
 		722EE77D1B193ABD00934EF3 /* ZGVirtualMemoryStringReading.m in Sources */ = {isa = PBXBuildFile; fileRef = 722EE77C1B193ABD00934EF3 /* ZGVirtualMemoryStringReading.m */; };
@@ -316,6 +317,7 @@
 		72130FFA2BF00FBD00691AED /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = "Bit Slicer/ru.lproj/[Code] Edit Variable Address.strings"; sourceTree = "<group>"; };
 		721594FD24DF36360027F600 /* HexFiend.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HexFiend.framework; path = deps/HexFiend/HexFiend.framework; sourceTree = "<group>"; };
 		722CAADE19BB625E009C6AAE /* VariableDisplayTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VariableDisplayTest.m; sourceTree = "<group>"; usesTabs = 1; };
+		DEC0DE0000000000000000F1 /* ProcessUserIDTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProcessUserIDTest.m; sourceTree = "<group>"; usesTabs = 1; };
 		722CAAE019BBB5A1009C6AAE /* SearchVirtualMemoryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SearchVirtualMemoryTest.m; sourceTree = "<group>"; usesTabs = 1; };
 		722EE74D1B18D8B000934EF3 /* ZGChosenProcessDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ZGChosenProcessDelegate.h; path = "Bit Slicer/ZGChosenProcessDelegate.h"; sourceTree = "<group>"; };
 		722EE74E1B18F8CC00934EF3 /* ZGShowMemoryWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ZGShowMemoryWindow.h; path = "Bit Slicer/ZGShowMemoryWindow.h"; sourceTree = "<group>"; };
@@ -1189,6 +1191,7 @@
 				77E2BBD718FDC45F00E41FA0 /* PointerFunctionSubstitutionTest.m */,
 				77E2BBAD18FD88A700E41FA0 /* LinearExpressionParsingTest.m */,
 				722CAADE19BB625E009C6AAE /* VariableDisplayTest.m */,
+				DEC0DE0000000000000000F1 /* ProcessUserIDTest.m */,
 				77E2BBA818FD88A700E41FA0 /* Supporting Files */,
 			);
 			path = "Bit Slicer Tests";
@@ -1587,6 +1590,7 @@
 				77E2BBB718FD8F6B00E41FA0 /* ZGCalculator.m in Sources */,
 				77A5B03019189CC9002BEC69 /* BinarySearchTest.m in Sources */,
 				722CAADF19BB625E009C6AAE /* VariableDisplayTest.m in Sources */,
+				DEC0DE0000000000000000B1 /* ProcessUserIDTest.m in Sources */,
 				776B62E6193126B7004BF4A0 /* ByteArraySearchTest.mm in Sources */,
 				77E2BBAE18FD88A700E41FA0 /* LinearExpressionParsingTest.m in Sources */,
 				77E2BBD818FDC45F00E41FA0 /* PointerFunctionSubstitutionTest.m in Sources */,

--- a/Bit Slicer/ZGDocumentWindowController.m
+++ b/Bit Slicer/ZGDocumentWindowController.m
@@ -1713,19 +1713,25 @@
 		else
 		{
 			// We failed to grant access to this process the user is trying to search in
-			// Notify the user why this may be the case
+			// Notify the user why this may be the case. Capture the process up front so the
+			// diagnosis and the resulting alert always refer to the same one, even if the
+			// selected process changes while the checks run.
+			ZGProcess *process = self.currentProcess;
 			dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-				BOOL isProtectedByEntitlement = [self isCurrentProcessProtectedByEntitlement];
-				BOOL isRunningAsDifferentUser = [self isCurrentProcessRunningAsDifferentUser];
+				BOOL isProtectedByEntitlement = [self isProcessProtectedByEntitlement:process];
+				BOOL knownToRunAsDifferentUser = [self isProcessKnownToRunAsDifferentUser:process];
 				dispatch_async(dispatch_get_main_queue(), ^{
-					if (isProtectedByEntitlement || !isRunningAsDifferentUser)
+					// Only blame elevated privileges when we positively know the target runs as a
+					// different user; if that couldn't be determined, fall back to the more general
+					// (and actionable) security protections message rather than guessing
+					if (isProtectedByEntitlement || !knownToRunAsDifferentUser)
 					{
-						ZGRunAlertPanelWithOKButtonAndHelp(ZGLocalizableSearchDocumentString(@"searchFailureAlertTitle"), [NSString stringWithFormat:ZGLocalizableSearchDocumentString(@"searchFailureSystemProtectionAlertMessageFormat"), self.currentProcess.name], self);
+						ZGRunAlertPanelWithOKButtonAndHelp(ZGLocalizableSearchDocumentString(@"searchFailureAlertTitle"), [NSString stringWithFormat:ZGLocalizableSearchDocumentString(@"searchFailureSystemProtectionAlertMessageFormat"), process.name], self);
 					}
 					else
 					{
 						// Not protected by entitlements but running as a different/root user, so Bit Slicer likely needs elevated privileges to access it
-						ZGRunAlertPanelWithOKButton(ZGLocalizableSearchDocumentString(@"searchFailureAlertTitle"), [NSString stringWithFormat:ZGLocalizableSearchDocumentString(@"searchFailureElevatedPrivilegesAlertMessageFormat"), self.currentProcess.name]);
+						ZGRunAlertPanelWithOKButton(ZGLocalizableSearchDocumentString(@"searchFailureAlertTitle"), [NSString stringWithFormat:ZGLocalizableSearchDocumentString(@"searchFailureElevatedPrivilegesAlertMessageFormat"), process.name]);
 					}
 				});
 			});
@@ -1733,10 +1739,10 @@
 	}
 }
 
-- (BOOL)isCurrentProcessProtectedByEntitlement
+- (BOOL)isProcessProtectedByEntitlement:(ZGProcess *)process
 {
 	char pathBuffer[PROC_PIDPATHINFO_MAXSIZE] = {0};
-	int numberOfBytesRead = proc_pidpath(self.currentProcess.processID, pathBuffer, sizeof(pathBuffer));
+	int numberOfBytesRead = proc_pidpath(process.processID, pathBuffer, sizeof(pathBuffer));
 	if (numberOfBytesRead > 0)
 	{
 		NSURL *fileURL = [[NSURL alloc] initFileURLWithFileSystemRepresentation:pathBuffer isDirectory:NO relativeToURL:nil];
@@ -1773,10 +1779,17 @@
 	return NO;
 }
 
-- (BOOL)isCurrentProcessRunningAsDifferentUser
+// Returns YES only when the target is known to run as a user other than the one running
+// Bit Slicer. A same-user process and a failed user id lookup (e.g. the process exited before
+// it could be read) both return NO, so an unknown result is treated the same as a same-user
+// process rather than assuming the target needs elevated privileges.
+//
+// Because ZGProcessList only lists other users' processes while Bit Slicer runs as root, a
+// different-user result is normally only reachable in a root session.
+- (BOOL)isProcessKnownToRunAsDifferentUser:(ZGProcess *)process
 {
 	uid_t processUserID;
-	return ([ZGProcess getUserID:&processUserID forProcessIdentifier:self.currentProcess.processID] && processUserID != getuid());
+	return ([ZGProcess getUserID:&processUserID forProcessIdentifier:process.processID] && processUserID != getuid());
 }
 
 // Show help for being unable to search likely due to security protections

--- a/Bit Slicer/ZGDocumentWindowController.m
+++ b/Bit Slicer/ZGDocumentWindowController.m
@@ -65,6 +65,7 @@
 #import "ZGNullability.h"
 #import "ZGCalculator.h"
 #import <libproc.h>
+#import <unistd.h>
 #import <Security/CodeSigning.h>
 #import <Security/SecCode.h>
 
@@ -1715,14 +1716,15 @@
 			// Notify the user why this may be the case
 			dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
 				BOOL isProtectedByEntitlement = [self isCurrentProcessProtectedByEntitlement];
+				BOOL isRunningAsDifferentUser = [self isCurrentProcessRunningAsDifferentUser];
 				dispatch_async(dispatch_get_main_queue(), ^{
-					if (isProtectedByEntitlement)
+					if (isProtectedByEntitlement || !isRunningAsDifferentUser)
 					{
 						ZGRunAlertPanelWithOKButtonAndHelp(ZGLocalizableSearchDocumentString(@"searchFailureAlertTitle"), [NSString stringWithFormat:ZGLocalizableSearchDocumentString(@"searchFailureSystemProtectionAlertMessageFormat"), self.currentProcess.name], self);
 					}
 					else
 					{
-						// While we don't show apps that are running as root user, some processes can still require the debugger running as root to access them
+						// Not protected by entitlements but running as a different/root user, so Bit Slicer likely needs elevated privileges to access it
 						ZGRunAlertPanelWithOKButton(ZGLocalizableSearchDocumentString(@"searchFailureAlertTitle"), [NSString stringWithFormat:ZGLocalizableSearchDocumentString(@"searchFailureElevatedPrivilegesAlertMessageFormat"), self.currentProcess.name]);
 					}
 				});
@@ -1769,6 +1771,12 @@
 		}
 	}
 	return NO;
+}
+
+- (BOOL)isCurrentProcessRunningAsDifferentUser
+{
+	uid_t processUserID;
+	return ([ZGProcess getUserID:&processUserID forProcessIdentifier:self.currentProcess.processID] && processUserID != getuid());
 }
 
 // Show help for being unable to search likely due to security protections

--- a/Bit Slicer/ZGProcess.h
+++ b/Bit Slicer/ZGProcess.h
@@ -76,6 +76,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)hasGrantedAccess;
 
+// Reads the user id that the given process is running as.
+// Returns YES and sets *outUserID on success, or NO if the process could not be found.
++ (BOOL)getUserID:(uid_t *)outUserID forProcessIdentifier:(pid_t)processIdentifier;
+
 - (ZGMemorySize)pointerSize;
 
 @end

--- a/Bit Slicer/ZGProcess.m
+++ b/Bit Slicer/ZGProcess.m
@@ -174,6 +174,27 @@
     return MACH_PORT_VALID(_processTask);
 }
 
++ (BOOL)getUserID:(uid_t *)outUserID forProcessIdentifier:(pid_t)processIdentifier
+{
+	struct kinfo_proc processInfo;
+	size_t processInfoSize = sizeof(processInfo);
+	int nameBuffer[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, processIdentifier};
+	
+	if (sysctl(nameBuffer, sizeof(nameBuffer) / sizeof(*nameBuffer), &processInfo, &processInfoSize, NULL, 0) != 0)
+	{
+		return NO;
+	}
+	
+	// A matching process fills in the structure; a missing one leaves the size at 0
+	if (processInfoSize == 0)
+	{
+		return NO;
+	}
+	
+	*outUserID = processInfo.kp_eproc.e_ucred.cr_uid;
+	return YES;
+}
+
 - (ZGMemorySize)pointerSize
 {
 	return ZG_PROCESS_POINTER_SIZE(_type);

--- a/Bit Slicer/ZGProcess.m
+++ b/Bit Slicer/ZGProcess.m
@@ -176,7 +176,7 @@
 
 + (BOOL)getUserID:(uid_t *)outUserID forProcessIdentifier:(pid_t)processIdentifier
 {
-	struct kinfo_proc processInfo;
+	struct kinfo_proc processInfo = {0};
 	size_t processInfoSize = sizeof(processInfo);
 	int nameBuffer[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, processIdentifier};
 	


### PR DESCRIPTION
Addresses the misleading search-failure message in #71.

When Bit Slicer can't acquire a task port for the target, the alert guesses the cause: hardened/restricted binaries get the actionable system-protection message (with Help → wiki), and everything else falls through to *"%@ cannot be searched because it may be running with elevated privileges."* As noted in #71 back in 2020, that fallback is usually wrong — the process list already filters to same-user processes, so same-user failures (hardened runtime without `get-task-allow`, iOS-on-Apple-Silicon apps, etc.) get the privileges message instead of the actionable help.

This adds `+[ZGProcess getUserID:forProcessIdentifier:]` (reads `cr_uid` via `kinfo_proc`, the same source `ZGProcessList` already uses) and only shows the elevated-privileges message when the target genuinely runs as a different/root user; otherwise it shows the system-protection message with its Help link.

`task_for_pid` doesn't provide a distinguishable failure code (it's `KERN_FAILURE` for essentially every denial), so the uid check is the most reliable signal I found without heavier heuristics.

Adds `ProcessUserIDTest` covering the helper (current process → current uid, launchd → root, nonexistent pid → NO).
